### PR TITLE
Replace `new_tensor`

### DIFF
--- a/src/tad_dftd4/charges.py
+++ b/src/tad_dftd4/charges.py
@@ -273,6 +273,7 @@ def solve(
     >>> print(total_charge.grad)
     tensor(0.6312)
     """
+    dd = {"device": positions.device, "dtype": positions.dtype}
 
     if model.device != positions.device:
         raise RuntimeError(
@@ -288,7 +289,7 @@ def solve(
             "to correctly set the dtype."
         )
 
-    eps = positions.new_tensor(torch.finfo(positions.dtype).eps)
+    eps = torch.tensor(torch.finfo(positions.dtype).eps, **dd)
 
     real = real_atoms(numbers)
     mask = real_pairs(numbers, diagonal=True)
@@ -314,7 +315,7 @@ def solve(
     eta = torch.where(
         real,
         model.eta[numbers] + torch.sqrt(torch.tensor(2.0 / math.pi)) / rad,
-        distances.new_tensor(1.0),
+        torch.tensor(1.0, **dd),
     )
     coulomb = torch.where(
         diagonal,
@@ -322,7 +323,7 @@ def solve(
         torch.where(
             mask,
             torch.erf(distances * gamma) / distances,
-            distances.new_tensor(0.0),
+            torch.tensor(0.0, **dd),
         ),
     )
     constraint = torch.where(

--- a/src/tad_dftd4/damping/atm.py
+++ b/src/tad_dftd4/damping/atm.py
@@ -82,6 +82,8 @@ def get_atm_dispersion(
     Tensor
         Atom-resolved ATM dispersion energy.
     """
+    dd = {"device": positions.device, "dtype": positions.dtype}
+
     s9 = s9.type(positions.dtype).to(positions.device)
     alp = alp.type(positions.dtype).to(positions.device)
 
@@ -109,7 +111,7 @@ def get_atm_dispersion(
             torch.cdist(
                 positions, positions, p=2, compute_mode="use_mm_for_euclid_dist"
             ),
-            positions.new_tensor(torch.finfo(positions.dtype).eps),
+            torch.tensor(torch.finfo(positions.dtype).eps, **dd),
         ),
         2.0,
     )
@@ -131,7 +133,7 @@ def get_atm_dispersion(
         * (r2jk <= cutoff2)
         * (r2jk <= cutoff2),
         0.375 * s / r5 + 1.0 / r3,
-        positions.new_tensor(0.0),
+        torch.tensor(0.0, **dd),
     )
 
     energy = ang * fdamp * c9

--- a/src/tad_dftd4/damping/rational.py
+++ b/src/tad_dftd4/damping/rational.py
@@ -62,7 +62,8 @@ def rational_damping(
     Tensor
         Values of the damping function.
     """
+    dd = {"device": distances.device, "dtype": distances.dtype}
 
-    a1 = param.get("a1", distances.new_tensor(defaults.A1))
-    a2 = param.get("a2", distances.new_tensor(defaults.A2))
+    a1 = param.get("a1", torch.tensor(defaults.A1, **dd))
+    a2 = param.get("a2", torch.tensor(defaults.A2, **dd))
     return 1.0 / (distances.pow(order) + (a1 * torch.sqrt(qq) + a2).pow(order))

--- a/src/tad_dftd4/ncoord/d4.py
+++ b/src/tad_dftd4/ncoord/d4.py
@@ -74,9 +74,10 @@ def get_coordination_number_d4(
     ValueError
         If shape mismatch between `numbers`, `positions` and `rcov` is detected.
     """
+    dd = {"device": positions.device, "dtype": positions.dtype}
 
     if cutoff is None:
-        cutoff = positions.new_tensor(defaults.D4_CN_CUTOFF)
+        cutoff = torch.tensor(defaults.D4_CN_CUTOFF, **dd)
 
     if rcov is None:
         rcov = cov_rad_d3[numbers]
@@ -102,7 +103,7 @@ def get_coordination_number_d4(
     distances = torch.where(
         mask,
         torch.cdist(positions, positions, p=2, compute_mode="use_mm_for_euclid_dist"),
-        positions.new_tensor(torch.finfo(positions.dtype).eps),
+        torch.tensor(torch.finfo(positions.dtype).eps, **dd),
     )
 
     # Eq. 6
@@ -115,6 +116,6 @@ def get_coordination_number_d4(
     cf = torch.where(
         mask * (distances <= cutoff),
         den * counting_function(distances, rc, **kwargs),
-        positions.new_tensor(0.0),
+        torch.tensor(0.0, **dd),
     )
     return torch.sum(cf, dim=-1)

--- a/src/tad_dftd4/ncoord/eeq.py
+++ b/src/tad_dftd4/ncoord/eeq.py
@@ -74,9 +74,10 @@ def get_coordination_number_eeq(
     ValueError
         If shape mismatch between `numbers`, `positions` and `rcov` is detected.
     """
+    dd = {"device": positions.device, "dtype": positions.dtype}
 
     if cutoff is None:
-        cutoff = positions.new_tensor(defaults.D4_CN_EEQ_CUTOFF)
+        cutoff = torch.tensor(defaults.D4_CN_EEQ_CUTOFF, **dd)
 
     if rcov is None:
         rcov = cov_rad_d3[numbers]
@@ -102,14 +103,14 @@ def get_coordination_number_eeq(
             p=2,
             compute_mode="use_mm_for_euclid_dist",
         ),
-        positions.new_tensor(torch.finfo(positions.dtype).eps),
+        torch.tensor(torch.finfo(positions.dtype).eps, **dd),
     )
 
     rc = rcov.unsqueeze(-2) + rcov.unsqueeze(-1)
     cf = torch.where(
         mask * (distances <= cutoff),
         counting_function(distances, rc, **kwargs),
-        positions.new_tensor(0.0),
+        torch.tensor(0.0, **dd),
     )
     cn = torch.sum(cf, dim=-1)
 
@@ -123,7 +124,7 @@ def cut_coordination_number(
     cn: Tensor, cn_max: Tensor | float | int = defaults.D4_CN_EEQ_MAX
 ):
     if isinstance(cn_max, (float, int)):
-        cn_max = cn.new_tensor(cn_max)
+        cn_max = torch.tensor(cn_max, device=cn.device, dtype=cn.dtype)
 
     if cn_max > 50:
         return cn


### PR DESCRIPTION
Create tensors from floats with

```python
torch.tensor(<float>, device=<tensor>.device, dtype=<tensor>.dtype) 
```

instead of using

```python
<tensor>.new_tensor(<float>) 
```

The latter has side effects (copies additional data beside dtype and device) that become apparent in more advanced AD applications.